### PR TITLE
Add page for picking players to start match

### DIFF
--- a/lib/components/player_picker.dart
+++ b/lib/components/player_picker.dart
@@ -1,9 +1,43 @@
+import 'dart:developer';
+
 import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
 import 'package:keepscore/bloc/auth/auth_model.dart';
 import 'package:keepscore/bloc/users/users_bloc.dart';
+import 'package:keepscore/components/square_avatar.dart';
 import 'package:keepscore/components/user_tile.dart';
+import 'package:keepscore/defaults.dart';
 
-class PlayerPicker extends StatelessWidget {
+class PlayerPicker extends StatefulWidget {
+  @override
+  _PlayerPickerState createState() => _PlayerPickerState();
+}
+
+class _PlayerPickerState extends State<PlayerPicker> {
+  List<dynamic> _players = List.filled(4, null, growable: false);
+
+  void addPlayer(String uid) {
+    setState(() {
+      // Unselect and keep position if already added
+      if (_players.contains(uid)) {
+        int replaceIndex = _players.indexOf(uid);
+        _players[replaceIndex] = null;
+        log(_players.toString());
+        return;
+      }
+
+      // Replace the first available position in the array
+      int firstNull = _players.indexOf(null);
+      _players[firstNull] = uid;
+    });
+  }
+
+  void resetPlayers() {
+    setState(() {
+      _players = List.filled(4, null, growable: false);
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     final bloc = UsersProvider.of(context);
@@ -13,19 +47,221 @@ class PlayerPicker extends StatelessWidget {
 
     return StreamBuilder(
       stream: bloc.users,
-      // initialData: bloc.,
       builder: (BuildContext context, AsyncSnapshot<List<User>> snapshot) {
         // @todo; Remove null check
         List<User> users = snapshot.data!;
+        bool allPlayersSelected = !_players.contains(null);
+
+        bool noSelection = _players.every((element) => element == null);
 
         return Container(
           padding: EdgeInsets.symmetric(vertical: 20, horizontal: 10),
-          child: GridView.count(
-            crossAxisCount: 3,
-            children: users.map((user) => UserTile(user)).toList(),
+          child: Column(
+            children: [
+              Expanded(
+                flex: 1,
+                child: GridView.count(
+                  crossAxisCount: 3,
+                  children: users.map((user) {
+                    bool isSelected = _players.contains(user.uid);
+                    int position = _players.indexOf(user.uid) + 1;
+
+                    bool teamA = position.clamp(1, 2) == position;
+
+                    return Opacity(
+                      opacity: allPlayersSelected && !isSelected ? 0.5 : 1,
+                      child: Container(
+                        margin: EdgeInsets.all(5),
+                        padding: EdgeInsets.all(4),
+                        decoration: BoxDecoration(
+                          color: isSelected ? GRAY_DARK : null,
+                          borderRadius: BORDER_RADIUS,
+                        ),
+                        child: GestureDetector(
+                          onTap: () => addPlayer(user.uid),
+                          child: Stack(
+                            children: [
+                              isSelected
+                                  ? Row(
+                                      children: [
+                                        Text(teamA ? 'Team A' : 'Team B'),
+                                        Text('-'),
+                                        Text((position % 2 == 1)
+                                            ? '[A]'
+                                            : '[D]'),
+                                      ],
+                                    )
+                                  : SizedBox.shrink(),
+                              UserTile(user),
+                            ],
+                          ),
+                        ),
+                      ),
+                    );
+                  }).toList(),
+                ),
+              ),
+              noSelection
+                  ? SizedBox.shrink()
+                  : PlayerPickerSummary(
+                      users,
+                      _players,
+                      addPlayer,
+                      resetPlayers,
+                    )
+            ],
           ),
         );
       },
+    );
+  }
+}
+
+class PlayerPickerSummary extends StatelessWidget {
+  final List<User> users;
+  final List<dynamic> players;
+  final void Function(String) addPlayer;
+  final void Function() resetPlayers;
+
+  PlayerPickerSummary(
+    this.users,
+    this.players,
+    this.addPlayer,
+    this.resetPlayers,
+  );
+
+  User findPlayer(String uid, List<User> users) {
+    return users.firstWhere((u) => u.uid == uid);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    List teamA = players.sublist(0, 2);
+    List teamB = players.sublist(2, 4);
+
+    return Container(
+      // height: 140,
+      margin: EdgeInsets.symmetric(
+        vertical: 20,
+        horizontal: 5,
+      ),
+      padding: EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        color: GRAY_DEFAULT,
+        borderRadius: BORDER_RADIUS,
+      ),
+      child: Column(
+        children: [
+          Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              // Merge different lists to place a "vs." text in the middle
+              children: [
+                teamA
+                    .map(
+                      (player) => GestureDetector(
+                        onTap: () => addPlayer(player),
+                        child: Container(
+                          height: 56,
+                          width: 56,
+                          color: GRAY_DARK,
+                          child: player == null
+                              ? SizedBox.shrink()
+                              : SquaredAvatar(
+                                  findPlayer(player, users).photoURL,
+                                  48,
+                                ),
+                        ),
+                      ),
+                    )
+                    .toList(),
+                [
+                  Text(
+                    'vs.',
+                    style: GoogleFonts.montserrat(
+                      fontWeight: FontWeight.bold,
+                      fontSize: 18,
+                    ),
+                  )
+                ],
+                teamB
+                    .map(
+                      (player) => GestureDetector(
+                        onTap: () => addPlayer(player),
+                        child: Container(
+                          height: 56,
+                          width: 56,
+                          color: GRAY_DARK,
+                          child: player == null
+                              ? SizedBox.shrink()
+                              : SquaredAvatar(
+                                  findPlayer(player, users).photoURL,
+                                  48,
+                                ),
+                        ),
+                      ),
+                    )
+                    .toList(),
+              ].expand((x) => x).toList()),
+          SizedBox(
+            height: 20,
+          ),
+          Row(
+            children: [
+              Container(
+                width: 56,
+                child: ElevatedButton(
+                  onPressed: () => resetPlayers(),
+                  style: ButtonStyle(
+                    elevation: MaterialStateProperty.all<double>(0),
+                    padding: MaterialStateProperty.all<EdgeInsetsGeometry>(
+                      EdgeInsets.symmetric(
+                        vertical: 14,
+                      ),
+                    ),
+                    backgroundColor: MaterialStateProperty.all<Color>(
+                      Colors.black,
+                    ),
+                    foregroundColor: MaterialStateProperty.all<Color>(
+                      Colors.white,
+                    ),
+                  ),
+                  child: Icon(
+                    Icons.refresh,
+                  ),
+                ),
+              ),
+              SizedBox(
+                width: 10,
+              ),
+              Expanded(
+                child: ElevatedButton.icon(
+                    onPressed: () => {},
+                    style: ButtonStyle(
+                      elevation: MaterialStateProperty.all<double>(0),
+                      padding: MaterialStateProperty.all<EdgeInsetsGeometry>(
+                        EdgeInsets.symmetric(
+                          vertical: 14,
+                          horizontal: 20,
+                        ),
+                      ),
+                      backgroundColor: MaterialStateProperty.all<Color>(
+                        Colors.black,
+                      ),
+                      foregroundColor: MaterialStateProperty.all<Color>(
+                        Colors.white,
+                      ),
+                    ),
+                    icon: Icon(
+                      Icons.bolt,
+                      size: 24,
+                    ),
+                    label: Text('Start Match')),
+              )
+            ],
+          )
+          // SquaredAvatar(findPlayer(players[1], users).photoURL, 48),
+        ],
+      ),
     );
   }
 }

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -11,7 +11,6 @@ class HomePage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final authBloc = AuthProvider.of(context);
     final bloc = MatchesProvider.of(context);
     // Fetch data
     bloc.getMatches();


### PR DESCRIPTION
This PR adds an unfinished view for selecting players to start a match.

**Expected Behavior:**

- Only 4 players can be selected
- The players are selected in this order:
   1. Team A - Attack Position
   2. Team A - Defense Position
   3. Team B - Attack Position
   4. Team B - Defense Position
- If a player is unselected by clicking the avatar image, the player is removed from the selection but the order is kept
- Empty spots (first time, or free spots after a player is unselected) are filled from first to last following the order above.
- When 4 players have been selected, all the other avatars are greyed out and can't be selected until a new spot is free.

**Screenshot**:
<img width="442" alt="Screen Shot 2021-03-29 at 23 45 47" src="https://user-images.githubusercontent.com/5709736/112904359-1e982800-90e9-11eb-9d3c-a75c2263fa7c.png">

**Video Example**:
https://user-images.githubusercontent.com/5709736/112904800-c7468780-90e9-11eb-8c32-ade2d9ea7c65.mp4

